### PR TITLE
Enabling DevOps Guru to monitor serverless resources by tag devops-guru-aiops=serverless

### DIFF
--- a/infrastructure/cdk/bin/cdk.ts
+++ b/infrastructure/cdk/bin/cdk.ts
@@ -2,7 +2,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 import cdk = require('aws-cdk-lib');
-
+import { Tags } from 'aws-cdk-lib';
 import { MainLayer } from '../lib/layer/mainLayer';
 import { NRTAProps } from '../lib/nrta';
 import { Utils } from '../lib/util/utils'
@@ -55,7 +55,9 @@ Utils.checkforExistingBuckets(initProps.getBucketNames())
         if (listOfExistingBuckets && listOfExistingBuckets.length > 0)
             console.log("# The following buckets are NOT being created because they already exist: ", listOfExistingBuckets);
         initProps.addParameter('existingbuckets', listOfExistingBuckets);
-        new MainLayer(app, initProps.getApplicationName(), initProps);
+        const stack = new MainLayer(app, initProps.getApplicationName(), initProps);
+
+        Tags.of(stack).add('devops-guru-aiops', 'serverless');
 })
     .catch((errorList) => {
         console.log(errorList);

--- a/infrastructure/enabledevopsguru.sh
+++ b/infrastructure/enabledevopsguru.sh
@@ -6,6 +6,6 @@ echo ENABLING AMAZON DEVOPS GURU
 echo this must run from the 'infrastructure' folder
 echo #############################
 ## configuring
-aws devops-guru update-resource-collection --action ADD --resource-collection CloudFormation={StackNames=[$envname]} --region ${AWS_REGION}
+aws devops-guru update-resource-collection --region ${AWS_REGION} --action ADD --resource-collection '{"Tags": [{"AppBoundaryKey": "devops-guru-aiops", "TagValues": ["serverless"]}]}';
 echo AMAZON DEVOPS GURU ENABLED
 echo ### DONE


### PR DESCRIPTION

*Description of changes:*

1. Imported Tags from aws-cdk-lib with `import { Tags } from 'aws-cdk-lib'`;
2. Tagged the stack with `Tags.of(stack).add('devops-guru-aiops', 'serverless');`
3. Changed DevOps Guru monitoring from Cloudformation Stacks to Tags